### PR TITLE
feat: OAuth 로그인 프로세스 추가

### DIFF
--- a/.changeset/silent-fans-thank.md
+++ b/.changeset/silent-fans-thank.md
@@ -1,0 +1,5 @@
+---
+"i18next-google-sheet": minor
+---
+
+OAuth 로그인 프로세스 추가

--- a/README.md
+++ b/README.md
@@ -44,9 +44,27 @@ i18next-google-sheet는 시트에서 번역 문자열을 인식할 범위를 따
 시트 이름만 지정해주면 됩니다.
 
 ### 구글 시트 API 키 받기
+
+#### 서비스 계정 사용
 https://cloud.google.com/iam/docs/creating-managing-service-account-keys
 
 위 문서를 참고하여 구글 시트를 접근할 수 있는 서비스 계정을 생성하고, JSON 키를 받아와야 합니다.
+
+#### OAuth 사용
+사용자의 컴퓨터에서 직접 스크립트를 실행하는 경우 OAuth를 사용할 수도 있습니다. 앱에 기본적으로
+OAuth 키가 내장되어 있지만, 현재로써는 내부 사용자만 사용할 수 있게 되어 있기 때문에 외부에서는
+사용할 수 없습니다.
+
+`i18next-google-sheet`를 실행할 때 `credentials-file`, `credentials-json`을 넣지 않는
+경우에 알아서 OAuth 로그인 프로세스를 실행하게 됩니다.
+
+한 번 인증을 완료한 경우에는 `.config/i18next-google-sheet-nodejs/credentials.json`에
+인증 정보가 저장됩니다.
+
+https://cloud.google.com/nodejs/docs/reference/google-auth-library/latest#oauth2
+
+필요한 경우 위 문서를 참고하여 직접 OAuth 키를 발급하여, `oauth-client-file`을 통해
+경로를 지정하여 사용할 수 있습니다.
 
 ### i18next-parser 실행
 i18next-google-sheet는 이미 생성된 locales 파일에 의존하기 때문에, i18next-parser 등의
@@ -63,8 +81,9 @@ i18next-google-sheet는 아래와 같은 파라미터를 받습니다.
 - `path` - `ko/common.json` 과 같은 JSON 파일이 들어있는 locales 디렉토리
 - `range` - 스프레드시트에서 데이터를 읽고 쓸 범위
 - `spreadsheet-id` - 스프레드시트 고유 ID
-- `credentials-file` - (택1) 구글 API 콘솔에서 받은 credentials JSON 파일 경로
-- `credentials-json` - (택1) 구글 API 콘솔에서 받은 credentials JSON 본문
+- `credentials-file` - (선택) 구글 API 콘솔에서 받은 credentials JSON 파일 경로
+- `credentials-json` - (선택) 구글 API 콘솔에서 받은 credentials JSON 본문
+- `oauth-client-file` - (선택) 구글 API OAuth 2.0 클라이언트 ID JSON 파일 경로
 
 JSON의 경우에는 `I18NEXT_CREDENTIALS_JSON`와 같은 환경변수로도 전달할 수 있습니다.
 
@@ -76,8 +95,8 @@ import { i18nextGoogleSheet } from 'i18next-google-sheet';
 const stats = await i18nextGoogleSheet({
   path: 'locales/',
   range: '시트1',
-  spreadsheetId: 'ABCDEFG1234567',
-  credentialsFile: './credentials.json',
+  spreadsheet_id: 'ABCDEFG1234567',
+  credentials_file: './credentials.json',
 });
 ```
 

--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -33,6 +33,10 @@ async function main() {
       describe: '구글 API 인증 JSON',
       type: 'string',
     })
+    .option('oauth-client-file', {
+      describe: '구글 API OAuth 2.0 클라이언트 ID 파일',
+      type: 'string',
+    })
     .demandOption(['path', 'range', 'spreadsheet-id'])
     .env('I18NEXT')
     .help('h')
@@ -45,6 +49,7 @@ async function main() {
     spreadsheet_id: argv.spreadsheetId,
     credentials_file: argv.credentialsFile,
     credentials_json: argv.credentialsJson,
+    oauth_client_file: argv.oauthClientFile,
   });
 
   if (['added', 'updated', 'reused', 'pruned'].every((v) => stats[v].count === 0)) {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,14 @@
   "dependencies": {
     "chalk": "^5.1.2",
     "dayjs": "^1.11.6",
+    "env-paths": "^3.0.0",
     "googleapis": "^108.0.0",
     "lodash": "^4.17.21",
+    "make-dir": "^3.1.0",
     "mkdirp": "^1.0.4",
+    "open": "^8.4.0",
     "ora": "^6.1.2",
+    "server-destroy": "^1.0.1",
     "yargs": "^17.6.0"
   },
   "devDependencies": {
@@ -40,6 +44,7 @@
     "@types/lodash": "^4.14.186",
     "@types/mkdirp": "^1.0.2",
     "@types/node": "^18.11.3",
+    "@types/server-destroy": "^1.0.1",
     "@types/yargs": "^17.0.13",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",

--- a/src/googleAuth.ts
+++ b/src/googleAuth.ts
@@ -1,9 +1,36 @@
 import fs from 'fs/promises';
+import debug from 'debug';
 import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import http from 'http';
+import open from 'open';
+import serverDestroy from 'server-destroy';
+import envPaths from 'env-paths';
+import makeDir from 'make-dir';
+import path from 'path';
+
+// Default keys configuration.
+// It is not possible to keep client secret securely in native applications;
+// therefore we just expose these configurations in the source client.
+// (While MITM is possible with revealed client secret, this is ignorable)
+const DEFAULT_KEYS = {
+  web: {
+    client_id: '491230429507-g47q0n19mc23a1nc6pq06ptuhbl3hu1k.apps.googleusercontent.com',
+    project_id: 'i18next-sheet-sync',
+    auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+    token_uri: 'https://oauth2.googleapis.com/token',
+    auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
+    client_secret: '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',
+    redirect_uris: ['http://localhost:48192/oauth2callback'],
+  }
+};
+
+const debugLog = debug('i18next-google-sheet:googleAuth');
 
 export async function createGoogleAuth(
   credentials_file?: string,
   credentials_json?: string,
+  oauth_client_file?: string,
 ) {
   let credentials;
   if (credentials_file != null) {
@@ -11,7 +38,8 @@ export async function createGoogleAuth(
   } else if (credentials_json != null) {
     credentials = JSON.parse(credentials_json);
   } else {
-    throw new Error('Credentials file or json must be specified');
+    debugLog('Credentials file or json is not specified; Using OAuth Login');
+    return createGoogleAuthOAuth(oauth_client_file);
   }
   const auth = new google.auth.GoogleAuth({
     credentials,
@@ -21,3 +49,86 @@ export async function createGoogleAuth(
   return client;
 }
 
+export async function createGoogleAuthOAuth(
+  oauth_client_file?: string,
+): Promise<OAuth2Client> {
+  let keys: any;
+  if (oauth_client_file != null) {
+    keys = JSON.parse(await fs.readFile(oauth_client_file, 'utf-8'));
+  } else {
+    keys = DEFAULT_KEYS;
+  }
+  const client = new OAuth2Client(
+    keys.web.client_id,
+    keys.web.client_secret,
+    keys.web.redirect_uris[0],
+  );
+  // Scan config directory to check if tokens are stored before
+  const paths = envPaths('i18next-google-sheet');
+  const configDir = paths.config;
+  const credentialsFilePath = path.resolve(configDir, 'credentials.json');
+  await makeDir(configDir);
+  let initialCredentials: Record<string, string> = {};
+  client.on('tokens', async (tokens) => {
+    debugLog('Saving credentials');
+    await fs.writeFile(credentialsFilePath, JSON.stringify({
+      ...initialCredentials,
+      ...tokens,
+    }), 'utf-8');
+    debugLog('Credentials saved');
+  });
+  try {
+    const file = await fs.readFile(credentialsFilePath, 'utf-8');
+    const credentials = JSON.parse(file);
+    initialCredentials = credentials;
+    client.setCredentials(credentials);
+    await client.request({
+      method: 'POST',
+      url: 'https://oauth2.googleapis.com/tokeninfo',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+    // Assume the credentials are correct
+    return client;
+  } catch (e) {
+    // Bailing out
+    debugLog('Saved credentials do not exist or are invalid; skipping to login process');
+  }
+  return new Promise((resolve, reject) => {
+    const PORT = 48192;
+    const server = http
+      .createServer(async (req, res) => {
+        try {
+          if (req.url!.indexOf('/oauth2callback') > -1) {
+            // Acquire the code from the querystring, and close the web server.
+            const qs = new URL(req.url!, 'http://localhost:' + PORT)
+              .searchParams;
+            const code = qs.get('code')!;
+            res.end('Authentication successful! Please return to the console.');
+            server.destroy();
+
+            // Now that we have the code, use that to acquire tokens.
+            const r = await client.getToken(code);
+
+            // Make sure to set the credentials on the OAuth2 client.
+            client.setCredentials(r.tokens);
+            resolve(client);
+          }
+        } catch (e) {
+          reject(e);
+        }
+      })
+      .listen(PORT, () => {
+        const authorize_url = client.generateAuthUrl({
+          access_type: 'offline',
+          scope: ['https://www.googleapis.com/auth/spreadsheets'],
+          prompt: 'consent',
+        });
+        // open the browser to the authorize url to start the workflow
+        console.log('Please continue to following URL:', authorize_url);
+        open(authorize_url, { wait: false }).then(cp => cp.unref());
+      });
+    serverDestroy(server);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,16 @@ export interface I18nextGoogleSheetOptions {
   spreadsheet_id: string;
   credentials_file?: string;
   credentials_json?: string; 
+  oauth_client_file?: string;
 }
 
 export async function i18nextGoogleSheet(options: I18nextGoogleSheetOptions): Promise<ProcessStats> {
   const stats = createProcessStats();
-  const googleClient = await createGoogleAuth(options.credentials_file, options.credentials_json);
+  const googleClient = await createGoogleAuth(
+    options.credentials_file,
+    options.credentials_json,
+    options.oauth_client_file,
+  );
   const sheets = google.sheets({ version: 'v4', auth: googleClient });
   const file_locale = await oraPromise(
     loadFileLocale(options.path),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "rootDir": "src",
     "types": ["node"],
     "allowJs": true,
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,6 +409,13 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
   integrity sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==
 
+"@types/server-destroy@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/server-destroy/-/server-destroy-1.0.1.tgz#6010a89e2df4f2c15a265fe73c70fd3641486530"
+  integrity sha512-77QGr7waZbE0Y0uF+G+uH3H3SmhyA78Jf2r5r7QSrpg0U3kSXduWpGjzP9PvPLR/KCy+kHjjpnugRHsYTnHopg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1003,6 +1010,11 @@ enquirer@^2.3.0:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
+
+env-paths@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-3.0.0.tgz#2f1e89c2f6dbd3408e1b1711dd82d62e317f58da"
+  integrity sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2093,6 +2105,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+make-dir@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
+  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+  dependencies:
+    semver "^6.0.0"
+
 map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -2660,7 +2679,7 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -2671,6 +2690,11 @@ semver@^7.3.7:
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+server-destroy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
+  integrity sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
사용자 컴퓨터에서 별도의 인증 키 발급 없이 사용할 수 있도록, OAuth 로그인 프로세스를 추가합니다.

아래처럼 인증 키 관련 설정을 지정하지 않는 경우 자동적으로 OAuth 프로세스를 사용합니다.

```bash
npx i18next-google-sheet --path locales/ --range "시트1" --spreadsheet-id "ABCDEFG1234567"
```