### PR TITLE
feat: action option 추가 (동기화 방식)

### DIFF
--- a/.changeset/hip-hornets-act.md
+++ b/.changeset/hip-hornets-act.md
@@ -1,0 +1,5 @@
+---
+"i18next-google-sheet": minor
+---
+
+sync, push, pull등의 동기화방식을 설정하는 action option 추가

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ i18next-google-sheet는 아래와 같은 파라미터를 받습니다.
 - `credentials-file` - (선택) 구글 API 콘솔에서 받은 credentials JSON 파일 경로
 - `credentials-json` - (선택) 구글 API 콘솔에서 받은 credentials JSON 본문
 - `oauth-client-file` - (선택) 구글 API OAuth 2.0 클라이언트 ID JSON 파일 경로
+- `action` - (선택) 동기화 방식에 대한 옵션 - `sync` | `push` | `pull` (default: `sync`)
 
 JSON의 경우에는 `I18NEXT_CREDENTIALS_JSON`와 같은 환경변수로도 전달할 수 있습니다.
 

--- a/bin/index.mjs
+++ b/bin/index.mjs
@@ -42,6 +42,11 @@ async function main() {
       type: 'boolean',
       default: true
     })
+    .option('action', {
+      describe: 'sync, push, pull등의 동기화 action type',
+      type: 'string',
+      default: 'sync'
+    })
     .demandOption(['path', 'range', 'spreadsheet-id'])
     .env('I18NEXT')
     .help('h')
@@ -56,6 +61,7 @@ async function main() {
     credentials_json: argv.credentialsJson,
     oauth_client_file: argv.oauthClientFile,
     escape_non_printable_unicode_characters: argv.escapeNonPrintableUnicodeCharacters,
+    action: argv.action,
   });
 
   if (['added', 'updated', 'reused', 'pruned'].every((v) => stats[v].count === 0)) {


### PR DESCRIPTION
https://croquis.slack.com/archives/C03KVL13SPQ/p1678244638299969

일전에 말씀드린대로 병렬로 작업후 병합되지 않은 브랜치들 때문에 catalog json파일이 충돌하는 이슈가 있어,
기존의 sync동작 방식외에도 push ( local => sheet), pull ( sheet => local )방식으로 동기화를 할수 있도록 action 옵션을 추가하였습니다.